### PR TITLE
Fix #320

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,9 @@ jobs:
       - name: Update dev lambda functions
         if: github.ref == 'refs/heads/main'
         run: make prefix=hame-dev update-lambda -C infra
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
       - name: Report to slack
         if: github.ref == 'refs/heads/main'
         uses: slackapi/slack-github-action@v1.22.0

--- a/Makefile
+++ b/Makefile
@@ -32,17 +32,6 @@ rebuild:
 
 build-lambda:
 	docker compose -f docker-compose.dev.yml build db_manager koodistot_loader ryhti_client mml_loader
-	docker compose -f docker-compose.dev.yml up -d --no-deps db_manager koodistot_loader ryhti_client mml_loader
-	for func in db_manager koodistot_loader ryhti_client mml_loader; do \
-  	  rm -rf tmp_lambda; \
-  	  echo $$func; \
-	  docker cp hame-ryhti-$${func}-1:/var/task tmp_lambda; \
-	  cd tmp_lambda; \
-	  zip -r ../"$${func}.zip" .; \
-	  cd ..; \
-	  rm -rf tmp_lambda; \
-	done
-	docker compose -f docker-compose.dev.yml down -v
 
 revision:
 	cd database; \

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -6,13 +6,24 @@ update-lambda: update-db-manager update-koodistot-loader update-ryhti-client
 	echo "All updated"
 
 update-db-manager:
-	aws lambda update-function-code --function-name $(prefix)-db_manager --zip-file fileb://../db_manager.zip
+	aws ecr get-login-password --region $(AWS_REGION) | docker login --username AWS --password-stdin $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com
+	docker tag hame-ryhti-db_manager:latest $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/$(prefix)-db_manager:latest
+	docker push $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/$(prefix)-db_manager:latest
 
 update-koodistot-loader:
-	aws lambda update-function-code --function-name $(prefix)-koodistot_loader --zip-file fileb://../koodistot_loader.zip
+	aws ecr get-login-password --region $(AWS_REGION) | docker login --username AWS --password-stdin $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com
+	docker tag hame-ryhti-koodistot_loader:latest $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/$(prefix)-koodistot_loader:latest
+	docker push $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/$(prefix)-koodistot_loader:latest
 
 update-ryhti-client:
-	aws lambda update-function-code --function-name $(prefix)-ryhti_client --zip-file fileb://../ryhti_client.zip
+	aws ecr get-login-password --region $(AWS_REGION) | docker login --username AWS --password-stdin $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com
+	docker tag hame-ryhti-ryhti_client:latest $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/$(prefix)-ryhti_client:latest
+	docker push $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/$(prefix)-ryhti_client:latest
+
+update-mml-loader:
+	aws ecr get-login-password --region $(AWS_REGION) | docker login --username AWS --password-stdin $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com
+	docker tag hame-ryhti-mml_loader:latest $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/$(prefix)-mml_loader:latest
+	docker push $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/$(prefix)-mml_loader:latest
 
 log-db-manager:
 	aws logs tail "/aws/lambda/$(prefix)-db_manager"

--- a/infra/cloudwatch.tf
+++ b/infra/cloudwatch.tf
@@ -17,6 +17,13 @@ resource "aws_cloudwatch_log_group" "lambda_ryhti_client" {
   tags = local.default_tags
 }
 
+resource "aws_cloudwatch_log_group" "lambda_mml_loader" {
+  name              = "/aws/lambda/${aws_lambda_function.mml_loader.function_name}"
+
+  retention_in_days = 30
+  tags = local.default_tags
+}
+
 resource "aws_cloudwatch_log_group" "x-road_securityserver" {
   name              = "/aws/ecs/${aws_ecs_task_definition.x-road_securityserver.family}"
   retention_in_days = 30

--- a/infra/hame-dev.tfvars.enc.json
+++ b/infra/hame-dev.tfvars.enc.json
@@ -1,67 +1,68 @@
 {
-	"AWS_REGION_NAME": "ENC[AES256_GCM,data:Pu26Apw31BBA2DmP,iv:5gZPPdqbBDXO0zp0xLVVPX84VLedFlxSa2LQjamu3p0=,tag:9YeB2SX86PjV+cubUZjnRQ==,type:str]",
-	"AWS_LAMBDA_USER": "ENC[AES256_GCM,data:W4zbjJI3sGEr6q7yhjNt1SgsgLPKgTM=,iv:YurQ1QEYzfz8V2hKsuCtwacIX29wucKmBZOnHm7nMZw=,tag:eGtjaES1XYfLY/mS14JjCQ==,type:str]",
-	"AWS_HOSTED_DOMAIN": "ENC[AES256_GCM,data:ug+7HrawNQbbqq21KZg=,iv:PpmT2erI3wlSRfxLGiQkV3cmgxu7f0IonTLx23cFZKw=,tag:N/dL5OtMKHA3BwfZUHCSxw==,type:str]",
-	"bastion_subdomain": "ENC[AES256_GCM,data:+O8oq7orHg==,iv:1lfFDunh5nyxeED6+5TYHZUzBrw7IDmCOuXSOs6xMYg=,tag:ywIpTmrtipoCe90UIuCJmg==,type:str]",
-	"x-road_host": "ENC[AES256_GCM,data:sRvspFUD1jQ=,iv:oNKJaFzZtzfmX4T7iKl671rR4gfLcNB68HfRmWQE92I=,tag:gfaZQOqh4x7pyia8CwdvJA==,type:str]",
-	"x-road_subdomain": "ENC[AES256_GCM,data:Ytl18Db4ZAPDbkWUo4CjTg==,iv:grNxF9JiS1ho+G725BconFIiUj5NWtWOpPiJCMJBEvc=,tag:+lIGI4l0ehq8tEKcMVsbBQ==,type:str]",
-	"x-road_verification_record": "ENC[AES256_GCM,data:EHGpzGsl1zAIZ4A2b0eHwCT/1ix744QSh1X8hNME+WW74l1uFmWTCQwpdLDLsH2Mxxd+Ug==,iv:/YuUlJU/z6+K2W4mWfeJ0Y0R2tfglvEgnQsgYFCTtEA=,tag:Rwfg4xG/ftxF+Z28EZzJ5w==,type:str]",
-	"x-road_member_code": "ENC[AES256_GCM,data:LQ/vjf8veBd/,iv:J+lfruWnA8OS7P5UObQ3tnDXSCHBfJ+AybNK1t7mhlM=,tag:qk4gA0evu42I3n3WmUmKyQ==,type:str]",
-	"enable_route53_record": "ENC[AES256_GCM,data:d8C/gA==,iv:RYG+mrA9O+vTmiuwBmMDK3V6F5ltdOcSo3a5pQ55WEE=,tag:0NH5DkEPd5+VrXBjP2D/WA==,type:bool]",
-	"hame_db_name": "ENC[AES256_GCM,data:BTooUDeWVD0=,iv:ghXL8e1mDg9UYQuHo/UNi28p5MlshZYHYnoPQEnENpc=,tag:AAe/Yj7kpooRMIhpqGk+3Q==,type:str]",
+	"AWS_REGION_NAME": "ENC[AES256_GCM,data:L+Sox5iwym7a4Qbk,iv:vwJ5idvN5uFz7Nv7u7l3i6lcWN+aElCRINpAKqrdxOU=,tag:S/CfzY28ds0JbV4eKP4q6Q==,type:str]",
+	"AWS_LAMBDA_USER": "ENC[AES256_GCM,data:5fL+lQwhLwFlIdqSR56wpk0lqTxxSYo=,iv:6oRPWzvlvDm9B3/8SiGIqUpVR7trH81/eTy9KVGlWQc=,tag:I87/vuJLte+TH05wNBmZmQ==,type:str]",
+	"AWS_HOSTED_DOMAIN": "ENC[AES256_GCM,data:89vHKWZGmM3sX4iC1IU=,iv:c1ItNYMLY8kra6Tbzc9ekTZ5/S437qEDIURxmmcNhX0=,tag:1Vlx4uuHRi/1kSzYy2ln6A==,type:str]",
+	"bastion_subdomain": "ENC[AES256_GCM,data:mWCa+c6ieQ==,iv:tqfAHErouxPxKTYDMfxt9twInNDjWro4cOQeGHjfi4Q=,tag:8puPSxIFQG+SynsaY7P4Mg==,type:str]",
+	"x-road_host": "ENC[AES256_GCM,data:alc//wDD3JM=,iv:/7PovuD6XHJji50bShnDDs0yGyqFtxLk+3yhoRMA/C4=,tag:NaGGps7M1f7027QHwnniYQ==,type:str]",
+	"x-road_subdomain": "ENC[AES256_GCM,data:S7ithEOlzHZTXV8/GikTsQ==,iv:7oyOYAf+N0UAvUNVdjIjPG2cqKkvUT6EP2742TcXLzc=,tag:tdBVzgiBmK+gfQCKcmlR7Q==,type:str]",
+	"x-road_verification_record": "ENC[AES256_GCM,data:B+qvuWh7Lx/kNaEV0eaSPDoOy8a6NtwKnYTrXo3aObMtK/cjvn8VsusXLMI4EhOBdlFW4g==,iv:W0K7rXuPCEOp15fCngSu+if/iWm/onTPtoTibaYL9MA=,tag:fd3WTgtBH62it0rkV+rM0w==,type:str]",
+	"x-road_member_code": "ENC[AES256_GCM,data:74KSu3ijPBQc,iv:vI6aZsYMYjrNRHc/K72lCf1U5kqq9LJtb2PHWqsm+9Y=,tag:gZ+U8qJzHO5qVYJWgNkMxA==,type:str]",
+	"enable_route53_record": "ENC[AES256_GCM,data:P56q0Q==,iv:o7OrNoALyJWKuJaj3ZAsqmuzc+lpIIQLOWW2baJ/0bE=,tag:717cm7sNJ79n8e2qgd//iQ==,type:bool]",
+	"hame_db_name": "ENC[AES256_GCM,data:qOVgVsvdfTU=,iv:t8LvgXFIan6yh0ck7DlzfSKf9Beu/M2lW4KXV5jWtC4=,tag:7/JAI2q4ARvZf6vJsCWEvg==,type:str]",
 	"su_secrets": {
-		"username": "ENC[AES256_GCM,data:5czR6Uew/A==,iv:dNp7eJdLmzyTCD5P9bZQ4LVfbE3Hc7kvFYEkCjMXTNU=,tag:1cJIUkgSDyas4vScxLY8uQ==,type:str]",
-		"password": "ENC[AES256_GCM,data:AHhssrNtD9JhjmpFzYX0x2c7ayAe0l9O9YJhz8R3MMQJXd5cxLvzgyhNfdEIW05ydeUx4H/uD+EJ2f5z/tXSzp0lIP56a37lK5Q7dnD1eWqjjY/vwPKwNfFhKKhVpqZj0WfoAdbrlKn8QMOj9dF8RFmi8En0NEyQ0xJXjTPAuUs=,iv:VB6L7wm0z2BLnNj7gaxqxkkQUxmkNbG9aum0J5ZgomM=,tag:3JwDjV2MnVFsjRyIw42N/w==,type:str]"
+		"username": "ENC[AES256_GCM,data:3z0I3W3Sjg==,iv:1mgW2y40WviAPXrvKi6XfpBZxQBqaXIkW3raiAvbMy8=,tag:16Am1PAvx3WTUM9Ltsz1fA==,type:str]",
+		"password": "ENC[AES256_GCM,data:DHen0tw50/QBhU3IguCTnhgUIxhF0sJnyVz8hYy4Fadoku6Fhx1cQQZuFkmKEFbjOiM49z2G7QBxEFW+oTpOeiEJ7nTCxnQPSgqd5KNbwebWg4gbQpxJm7v+53g9XtO68sZpXZqFrnI72uYwkcFFrQaeZl9USpQ70qikJnXarVk=,iv:T1Q9vQa0qeOXSQ4aTpunKRmotBOZ6qulLgro165QJps=,tag:EfI7rpTuJBkuIsK+YtOxFw==,type:str]"
 	},
 	"hame_admin_secrets": {
-		"username": "ENC[AES256_GCM,data:LBickXRt64yNHw==,iv:UwfnY9FH2vRz3Db41K6vVIclzNu0AjNPw31lJnLwhnM=,tag:NV9DJvmWuifxt/iI3V0p/A==,type:str]",
-		"password": "ENC[AES256_GCM,data:SgA4AKk7slP+PPIXaoAg2hdXPvQ0fKwTuNi/aKdHBlI4AvEtoYuY7E1nx/3FNISQJtm+UqqwojTzy6v1OORYEk7Db7wSPXqMVow3M8tqAG2yEA+GxYqF/nxDQp+7aBqixC9DRl8gIe9evqMKTAK8us0m2VSQJW7OJvmKWeHBGKQ=,iv:maNSvn/EP3Cb7oTHHplyw/s3yW/q7621zY/8Gaw+03U=,tag:gHi4qplhi7rRVq8xxzoagg==,type:str]"
+		"username": "ENC[AES256_GCM,data:u4/zG/aSXhL4Xw==,iv:C42VMX/W4cuW9rbtDpSwZxSc6VjcB2b21zsB5NnLeVM=,tag:VtCkJVc5bSHmdxZfx8OfoQ==,type:str]",
+		"password": "ENC[AES256_GCM,data:rag0wD/5xDfrv3xhDJsvwD0aXs3fGIXpHAXAdE8Tx/U84s1BKlIirq0D9pUjg4Gcaz4FiV/ODGLHP51iR8Kgf8kYuM6NMukI8lCNmdxXVe8LIQomAE9Z4wb52aLrGgrcPAqS0Kv6/u5g1TxmlEeGdBrFfUFLbLfoWqlQSwqrDxY=,iv:EYSUW+JUewc/bh0ZUabQmibbP+gTcr6eDs3+tcnS5tM=,tag:+A8H2lHBBpYOQLUNvaidFQ==,type:str]"
 	},
 	"hame_r_secrets": {
-		"username": "ENC[AES256_GCM,data:HA5GJQ/SW+s+,iv:xMQt2SwCVu7ikIK1jsjf1zNSfEyzxsGkJoYfW7OD1e0=,tag:6yz6FxnyHTN/ASYybXJ1RQ==,type:str]",
-		"password": "ENC[AES256_GCM,data:kctCmJfMikBjfYHCSrRPXEOplLmrdeTXu3Ajp/QEzjoWX/oc/fcKrVoamiKRUyt4+p5UVAdWu4MwTn3mIF2PHngcXN4drkmZApN+wfk2nn/7iutgkzda4+7ccME+xSfwGe2/AgiLUef9jQu9oO6vqe1UARygo6rtD0ZzOpEfxxM=,iv:ydTUxogWRVLHPXkxAeeV0ESJ2YCdvGZKVDxm54wXQWk=,tag:qKV+f923uyRJnyUnxlCu7w==,type:str]"
+		"username": "ENC[AES256_GCM,data:iPmYQUksTe8W,iv:My6bNydYwto1k4jC7Dl/fB7dc86k7qczCXCcoGbkDXY=,tag:+ZyQ8J9wE4ByaMEKSJrvUg==,type:str]",
+		"password": "ENC[AES256_GCM,data:wcfhBIWocmzXZ8iOZMWczasPM0Mt6upzfTSN6tbKMKac7braaMAah+fLPVVn+t9VEoiOoig85owYjTNc1DlBzzY/V80iDTlabJnc5de2Hf9IND7f0BcjvSwW0wE/7sRoWk96i9exFFiAJrURDWm/cV0pZIPiRB0mGMjdfIQK6D0=,iv:N0dpksdcJd9hjymZAz8GhnFl/h7YuOpAMHIEQSQelLQ=,tag:yHsfyEte2uRou9eIzYL0Zg==,type:str]"
 	},
 	"hame_rw_secrets": {
-		"username": "ENC[AES256_GCM,data:2tL5vNudvyZhVsIzN9Tk,iv:ffrN6w+ZsasFQ3IJgpdSq0pbPodA6oGIFDCWaZWpXJI=,tag:r+iBIXJ5gaSG8Npfctkh+w==,type:str]",
-		"password": "ENC[AES256_GCM,data:hO1pUOVLN1H5D7oPeWtGnIkFCfvPQfcKVi0v0UDn9h2Z9pu5lRdKLVnf6xP9PawdoEgX4Nkok6LA8AS37hL2NkHZx8oiV4Nm0szbbGjI8xSDfF7yliHG2p4cXTQM9B6Zfg+P4zP6hTrqr5Fq1kC4Ovpix+FicTDvOwJpHpH8Sc4=,iv:Wgd/MQtv2w+n9AsjWt1t03MHPyKLE4mMmWawYIwvnvM=,tag:gn0eg8w+ZIzFdE9LISawgw==,type:str]"
+		"username": "ENC[AES256_GCM,data:Y/4QIYjaAz5XVhpxkDcd,iv:yKkCx3m1uxdniFF6ViTsBaB5+Rjy7O2SKF/dQP2VT5g=,tag:9dOU9+t0a+AunvTm/80vPA==,type:str]",
+		"password": "ENC[AES256_GCM,data:sPLOZ5c0aOTcKGcpfANhkpY8KjvMpP12V0Uge3JHuPr6c2K/huhfb8dUh7iBWhobp6p7IOWKp5ALtjBGjI467my/ekwslnLcbLikeWauijPFJpDLoj1hf+KXHbiGnlr2+TnJeV9VQidn+zbcQeRNDOhhO6ZKXIZLyauGs4czllo=,iv:trYPZa5STxyjHtpUl28yn6hbVIZoyc0R3LGYl3TWuws=,tag:2eS717du/1V2v4vFrSBBjQ==,type:str]"
 	},
-	"x-road_db_password": "ENC[AES256_GCM,data:3P4H1t2BOmlZMuEhmTW6gK6uG6gwOoLpI0gYo54rqRPLbBonluSj4GlvaYy/R3gdqzZ7fnceyEN5M98X2InmZFZqjAtJZaLsf97++xHDvseXWlwfeFcHeHGfUMUbIXE3yJxL2WZLbwJJ1de+qOgyJt3qncqSATPsJLJohHTC/zE=,iv:7CLwj6hevkqIzS2TDiOsd7boB5XkBgyQkUOXJUR9WWU=,tag:ZtnbX2u+nkUJi1J560Ev8Q==,type:str]",
+	"x-road_db_password": "ENC[AES256_GCM,data:ZAAMKK3A8+AGxdJk7j9F1EkpuHojoZrgV4ziVWoBCHWb78xb8LOrBYJz4+rg6f0jaal0akRNiMurnO+DxNn6XqOMpFbeCPzg/4Etd23u27WIGd/IjKFi0zkl1nmyhVb8chAUdy+P+drLLd2v0PrTGCuggTC0hn0VOm/3PIOsHuo=,iv:LoIdLP3kOQv7cYkirubkG8/7YExWnuj62dgkZGpzxDc=,tag:PW1NxvRL6GimvEFd64D+DA==,type:str]",
 	"x-road_secrets": {
-		"admin_user": "ENC[AES256_GCM,data:SmCeGIX4kuw4ifE=,iv:oXJ5EKfha8D0HdJVbYtPGSJT9omkewBEr4vD4Ni2u3k=,tag:7XhzaT+i7F5Lpihy52SDRA==,type:str]",
-		"admin_password": "ENC[AES256_GCM,data:Vj+BrHPbS3V0PlMIuzAWNvymrTMXSufmoVvJWgwQtrhRiDb5scKsGQgMlYu3myefXy/oG0LEl1M/xodxfNaIFEWG6y0xHCLQT0XYEh19o8mA62dymjbmbst4x7+6IrGoZMKv6G2sk2Nk5hWeUyZA6Zs6Agj0OjgwsPeyLUZpbzg=,iv:id6rhqdpj/81cFCD/z90ElS1vqS5fXlXX0JKaK8kQU4=,tag:ZP0m8ib2UEfIDCYY8wiQOQ==,type:str]"
+		"admin_user": "ENC[AES256_GCM,data:6/G7GgFeVbS8ln4=,iv:Ue57sXnpl4aPmArOjNOrV82j2EtdF/O7OYQGKyul7ks=,tag:d67WXzXiQe12yQ5vthTkTQ==,type:str]",
+		"admin_password": "ENC[AES256_GCM,data:IKLWpJvdoPHfGSfBzNktz1KauqC//c45ICgcRwjarUpIqmzv0xYITYAeTTgd7I1gBzgeAutnIERllnJov1zJbmjEjqhCwYQRnYU4EBxWmiW+LF0T83r0ws1FRSvzCg6ZKx63laa8gCHk3PPjFaPVHh+TrT0/bR4uJVgk/ibRefw=,iv:rGC+Tjh2KI8QcjCe3MuBLMC8Svz+JxYIV7cawkgHGT0=,tag:QvVOTm5k+4kfF3X+F8FMiQ==,type:str]"
 	},
-	"prefix": "ENC[AES256_GCM,data:87j1ow85Ue4=,iv:9zPO1HijFTqyIH2BvHtHHxH9cmiB3LCe7E646f4clIk=,tag:Xjo+fg6eOJNJwwz/OML/1w==,type:str]",
+	"prefix": "ENC[AES256_GCM,data:Jd+kQWV3Imc=,iv:8KdOL7MlttiN8jBPfC1wVLHu2rBrKE6HiXLdks8F5q8=,tag:fKL2p6aQc5t22lpkaurL6Q==,type:str]",
 	"extra_tags": {
-		"Customer": "ENC[AES256_GCM,data:kN2gJl/UWZ7J63Qo,iv:ya83T+Ey0TvFacgqpbFfdDXjMJMg6RCqtMNQz+rbHfg=,tag:uD/ypPz0urs+wfV8WKl/BA==,type:str]",
-		"Project": "ENC[AES256_GCM,data:09nBgNSl1YiJ8Q==,iv:sgq0rUAHC9LESqDATwqi4fEB+wdmI4BztEEnSaH4uDs=,tag:08mD/OKDFdQLltJWOHK8tw==,type:str]",
-		"wrike_task_id": "ENC[AES256_GCM,data:oSsnu36aSdDoHw==,iv:/zVjLKWZceLa5xS+jjTLJl0xHzk1Deviwd2C+er2DTM=,tag:Qlh+HeZ+y2/6D2Lp+gKu8Q==,type:str]"
+		"Customer": "ENC[AES256_GCM,data:urVGMEsLcLWn5OI9,iv:I3nVZ8rLKC55DKlwK8ra4wTI24hSgGZDOdhaD42hmdg=,tag:au9PC8NbrO7K5cBzXfWE0Q==,type:str]",
+		"Project": "ENC[AES256_GCM,data:j2XJpIfNBdCh1A==,iv:HFvV4ACvixMKQ4Npo+NdCnZk7ldcocCpG+/Jz37UKUQ=,tag:lQ68p2Qt39v0BwBco84RMg==,type:str]",
+		"wrike_task_id": "ENC[AES256_GCM,data:uAr4/HVtAXonbw==,iv:iF/IKMpwBAnEUAZq+jIZoxt/iIidAUg5RNW/yxG945E=,tag:QfuqqaERTqQiwJj/pM0vtQ==,type:str]"
 	},
 	"SLACK_HOOK_URL": "",
-	"syke_apikey": "ENC[AES256_GCM,data:mOQ5lNChE1NNM9n8wdbh0LWATXcyPe8+05XAkcsngms=,iv:35MHeRqtVnPSYjyWXymU9CXfDufYzrXJ2CuyKg/QhGQ=,tag:j9X7JD25oZ2zBcz3B3iBdg==,type:str]",
-	"bastion_ec2_user_public_key": "ENC[AES256_GCM,data:rWiJWLuAwpeqVJn9c9BY0NpokCdxRJAOf/zpY1KYknLLJ7uvTwn1z1HvkrG2gKzk5n15u761Yp50XUQvq3auduMx74766ZcA9JTvBDX7nqM=,iv:qZiDraG63QFw3IcQB+iSj+RoB0OLsUxTF5PMlU8FKGA=,tag:tGYgdXa38ptE+Aai3bpB4g==,type:str]",
+	"syke_apikey": "ENC[AES256_GCM,data:AZOgT1CxVPvhIjLXs4DAb4ucfuvhRvNKtDVBMaaTpoE=,iv:y3unstEKjcCO4puHJOg1OmtiUBBxu6bqnihhLivSKv8=,tag:xBwlvEHQ9gQnAvjX5bVfxw==,type:str]",
+	"mml_apikey": "ENC[AES256_GCM,data:RlqLVQqgaP6e1XcvQaxQ5Pp55MxNO3QNWKZF/0WNoUmUVmu7,iv:Iq2ztv5xFbT2kxjMvT7SPnwYqy7BdSZxpM4px9dA71Q=,tag:iObqFzz2WvghlTZflwdN3A==,type:str]",
+	"bastion_ec2_user_public_key": "ENC[AES256_GCM,data:GcZPKNbGRko0W4F0iwjDXgdDjQnx1ddrFXbO0VCLFvUdlcuRZDv5VM+8BHprKqGBRGMWynkeazJFwp6iLboMh/SZ74mg3cr9+rK0nfek0pY=,iv:N4itpr2vnI72POPmLlbKBxtASJRWPY3OpItb/igZWaY=,tag:6QHXWlz4mrcNDSWGQLMA6Q==,type:str]",
 	"bastion_ec2_tunnel_public_keys": [
-		"ENC[AES256_GCM,data:LBRmSdMwP6WTkiALW4C+uypGHII0uW2ZDboY6FmH1PAB8wMuY/7naLzsIZ3xtNtyW4NGKH3RzTQMw7Zgkpis8V/w4u4j+6I8MZL+FXvpj9P+72ptF83o3I4MTLIUxbjcwg==,iv:FHSXDwNnbJ3y6rYr0h93QJsvb2sOrGiaT7VR/R+hYCw=,tag:Y73Lnf+Q1262Ui65IjKeyA==,type:str]",
-		"ENC[AES256_GCM,data:Zaa8klV2VFQeug1UXKexSXdxcGEA3yFmeIKG8Yv6GTFQ9v7s3x/zZ8aHj6EQHtzsGBXNECWdYwXkCzIGpM45TTnSzkKfYS63bpZauEzPZ9K8FIg6WPqeuZ84JTGp5A==,iv:LuH7nqTWcQ6F0rDeYktPJlM18ltxhPf1TaXzr0CggvE=,tag:JPbTrsEceO/tmTDqI7wG+Q==,type:str]",
-		"ENC[AES256_GCM,data:+EpEweuLYpHFWcEkpYi0s6FpWc3YuKiEmrH8xiLduvG00d1c1z3oFscN+hZukgB5Xvzc7mvyKL+vQYTNkrL3g+k8OJ9sCcnquBRZGcTNHcGctOG1fJHelTJjmINwl2o=,iv:DECXsM7g09y52KtMX9JvGXv2IFu0Jlle2JekRRUQS+A=,tag:mzZZXlvZcYtZrp9MO3bZlg==,type:str]",
-		"ENC[AES256_GCM,data:gDbRi1tWrIrhZC+pD9CJeOHGrvmhHEfIX/I4sP7OCTD1s29JONMb3R+MAdRbOqbcSoqJfug0f27fitpESGV0FIcYi3sM8oHmJ/HVvMU2XzL0S+kvPX8XqZ0x4yBPtFyliBdQq92m2A==,iv:tk7dV1jhbmbk6WIhy6qZ0R95iuv2FxBv+Fi9ObVCKwc=,tag:F3n279VvYSKBtCX+ixG5Ew==,type:str]",
-		"ENC[AES256_GCM,data:WjdK60HzobRZlyQM2SnPKK2EvWcwN1jKEe/ju7HMlyL/haL+INMWBCUwIqSb80jmevabUWuefzz24f09khSJr9qKzyQn0z+ctXgVGTLBCCYgzgXWmUyU3buajruJ6/pQ0tLQqI1Iqp58+czq,iv:yOtobCPtPTHrtka1woIk6XaXf7Ce2eKeLg+QZyuU7jo=,tag:74f8sIXUb51z4tXSy64ATw==,type:str]",
-		"ENC[AES256_GCM,data:bvDFfF5Y/A4yQfZiALHI9bDU2/RPBC/HcE3mYOoUEX4C3YuXMz3o46wmH2bVJZWieHP9vAvFOLKa88pYvlb3Wehc/L71XQqTw6m2h2wqcSly8IFRKd5B6zCJ/HDCTmNjU9pW3fA=,iv:BiynWv6bGrN+u6nWTdS62RXKRjwMOw1/ANUedI+eA3s=,tag:NJwdSF/4EedVUZfqDR++LQ==,type:str]",
-		"ENC[AES256_GCM,data:kKxQM/zUTc55QYBfdySk+gPTKWrdokegLFFl4QQnccLacoaG8FuaxwAm8pdPGIOFkZhGA7OJPikNfOyRsgsOSQ/798faEOJUGa6zMkHzn5sBCn1jUpg+f7pHF2uCnKjl,iv:Qxnm46cAcHp8GmChHd3/5DyRgFwB7WFZGRmllfnKyaU=,tag:9JZxv7yBpIlvIQAyk3anag==,type:str]",
-		"ENC[AES256_GCM,data:ExS9cpsJg30vwqFtakA17HHcdB3yrJ9cQssAhYmeTcCYkUD5san2leWoOW7sbbbVgPMMbGskPoh7P3Hsy7d6UhvNEDpogMilz5zocHIzNyJvqI9qi54FBCAywX6GGXZ1owLHmzJXGCFDfhfTncyjEHpyv5Y=,iv:n3crTJCVY8zAw7JI9YXPeLCAC4nMwXhEPcuV/4qjCD4=,tag:E46ZkyHjpLqKaBFpD21RPQ==,type:str]",
-		"ENC[AES256_GCM,data:+1NMYVnHlgoQOuJzXbp/IB7jkwr0QdW8m01/j2FinJaTqa73OyoR18zSmyTP0pFGLfb6x/f7bbjRv/m6+TWcEMLFLqIdR3u4RFKmNxWC5xpPezkTqOKgEZK4BHFkkzxOeEv3lhoO1TVHvXfngA==,iv:Yt30str/4uHdW6GBZZrPdyBSVz9gnDipCjCoBX8q2fY=,tag:5w+Af77dSv9CFDWtOduEjQ==,type:str]",
-		"ENC[AES256_GCM,data:jTTHj8qSAUcH2vJRZzqcZtES7FmrqHz2jEhK5OvrEcvsG3wW8Vrj1hEUWR2mi39/4kJ74rWq/TZyshjKMoCTCkM2h9VCNgB3GCfo/xf4msUxL6S18Ee720LbR61UtB1KbKuEB8MTkqs=,iv:YPQKdVXxcAfQoLL9SSfwFtM5mfKWLhrQqhx7Zi9fFH4=,tag:ISCKvt8oiJ5Kxhs1aSO71g==,type:str]",
-		"ENC[AES256_GCM,data:UvG3Lh/65ha/rXlfTeet1CrwRu3xzTYH8qYMwNdf5/q8GgY6QEMv2AxcThYjsjJz94ky48G1C5E/H7AX5oMkyEkNxGb0lcofhQcYHMWhrlc0bY6XOieGIlJDFR7Yy2KQlPMriRifC+0=,iv:l8kJx3WkEuhwC5zmhhGCzDh//hU3ZxWrQJiWDFQ317k=,tag:7CRZyqtprUx32XQSwfPYyA==,type:str]",
-		"ENC[AES256_GCM,data:TYWSMMVKfmOKWQNoSU3LvSOMVIQkYJauhxYAjrkkO643Z/ua7pNmMGoe5Sz1gvveTYoUFuaz9vvkT76n7bxTpagCPcJW0s89YD0mB4QuPszVm8/7XuPvo58ffvT56J7gq+1pXzuhzy/5ZwIhAkaw1S/u+Jriq3Sj5w6i/2k=,iv:MmQg1cDQ3eD5p+peA0P7xMSBUHYDmCYGPj36z2MJJ7s=,tag:zDJGUqjHEVKOlMbpniLYWQ==,type:str]",
-		"ENC[AES256_GCM,data:glIzb9TTu9s4GHRJcBDddD9l29Nfa2Q+gNaYvrSNjEvQLIhHNowW1CenFO5LSTdLQxrHoDXwSrDDdV8+XVLLVIavFY+YDoIsu7z4dTEp+X8C4eiPTsB9i0yaQkMA6wBbkVZuhtKB/niQ,iv:J9PAhE6yDj7UWJEYx7uRdEj7Ot84aSD6XE/jmuhmPAE=,tag:2O7yz1WjSidbwUOKMtx+6Q==,type:str]",
-		"ENC[AES256_GCM,data:j3fT0Tsv25CjwXWWsCVS3rhThd/n4WqxTa2O1a9Jcvf0KCeR9FmtZqM7UQY3KWH5xoqWaYzj9ulmoMKDe/NA/dLBsTU3CAmIXBnCgL9mlIDa+tHy8vRklRKox3s+DmIcWdu/kVNevJlirrgpMipsGZUEVIqsMxA=,iv:gCv/gbmjC+e971Gv23UPZEV1XJkOvVKuwSt32aDxYLk=,tag:wNpkuM9DWYh6xP/9V2ax9A==,type:str]",
-		"ENC[AES256_GCM,data:tSE3aodBbBStm/3QoPRlfQwDl52AgxWWxyH75wgHjpLUHT4OT+MJGDSFIKBBwzobihnmToCEGMTPlxgivGTMxO7993c2XRM1K1A44T0wBQ7+N9Z8Ey70hg6cVTN3FBW2VIauuyhV9T1IYnjBIvozlK233STvIpFi8E+hnhv1CVbj3pqG59wIHaHHcbMNEaHyGlbHpXygqGnTQod106agLmX9vBzA9YLFQYsZ/frV2omyUwBDaVmJ1blFwhs5n5aBtH68uNoOr1sTvRNnDyN+JWZ4qneUeNBr9HwsTF9+lZhvw5WkeCFyMkWHAt1/ZKZsGRJ3z1KwVl7oT6jTpfVH1K49T1Ds4e+o0DOKPUKBfG75iXYhDPOhjakz6KQNVPwqOXgfKGAflUUvvoq43ganIO17AvUhhH9nr+3Fdcq2ajxmFpgUe7MTTmIh/S8oWb9cIo1lvEj3cbu+b8pcJokHqBKsxWN1JkkrISptuE7wjYYgH2nFgt1Hv/1lg5cbrvCrecHIHLIrkzG+QCsfj/VvRkTziMrg6naBrDitBNYTUDAE78GEcrKLBpbBCpnRyWZXPE14LqcpxBrkwVd+bgSp2rgFVke4IlZ8otKad+xosq1vTI6NcSuKf8PVPUtAZtlFW4b4VIjjeyFIaguw71YRwGpZMbczQYOUUIqJDh3ThUEfVHQn3jiFF+IKMUMcldLhOrG2Uipbm9gH60E5bnvIVqSco/VaWfIKiMmMG08KTT/T5NrTSJSWFvPoVeuMVT8939KKtR3yNahjoiN5BzW2VkOEed9+1w2lra4Sn4+k5a0CgKXTjQEl4Vc0W/jSMwb5uhanGjTumtoUwiyaD+08x47TpHwm+cyZIX7hdz8YNHwzktT5Heae52rH1jV0YbRfQfsPz36mH/+rVQnP9VS2vj7ODGzULLnLCAtnIHW4esjVsOuW2rChVdRZwhju0U8mRPdwV4jDGfQR+jvwa8hV2QbmLkUUIkksa0RAEIiKJSw=,iv:5KyF1gAqd77f9TaefRm31Oga5JpOzk1/+K4SftR+XAw=,tag:gAfjDPtBFzA1CeLHIBFR0Q==,type:str]"
+		"ENC[AES256_GCM,data:UWSMh9vd67MIaBx4we+zwBQxgonWqd2ndFtN8DFYl86tzJBKtyyRcjCj8j+gDvxaOKM5PDKHPVpUNtX6+W7ZIGuCZApj4N1w7M8cJq13RoSRQRj78HV//svO8RPi1jDFOA==,iv:8w2JnK0g63yAIzwYXWZMH9WBnl+pDpvqxYIlpNqO2ak=,tag:Od1grmAYId+edbPloIGFWQ==,type:str]",
+		"ENC[AES256_GCM,data:XIp1c3uCIRDfTJQLL+rIe4iCZaKsdT623yX3XOsQceYKdwaVnZ9KTh1SGXy63miUzp6CW0D1yJtQWJz4ibL55u4drSx5ykmi8djUsjhoGwLnXSUI3glMSPRP6MEb8g==,iv:FtI6yb3Tv0VeOILqMPm4N89615MfV130si6uTOVo2WU=,tag:hLIFYVbXRnuhR8SM3+mO9A==,type:str]",
+		"ENC[AES256_GCM,data:Uxx3B85BEC0dx6XSR4GgtMjfUAxVC28utheN/gaNpKIpPnKwJDr2qVxM1T24aQajlH+1rPhVNfBHRFJZQzaGPBxLYzAx0e7Lz1Pe7lkwknCAoQOYabk52c+ysV6mweY=,iv:xk14lY8NSSpemz6vEptBRz2gAashQ+pHBnZ6jekyziA=,tag:cxHUT5g4G3ZJv4uoXd/1Tw==,type:str]",
+		"ENC[AES256_GCM,data:nJmzGt6w2FjMZWrOkkzQ11R2QUwmTuNczE5jPrEvUZGrJfhI9IBtrvmhzXZXBWPHIIREEMgw/O5qNGj7ngXAsxm8xeHTP0n4m/HVgB4dgYns/MDEyNdt50h3AdvsQD7j/tirS/oB4w==,iv:1R/yC05yPGSr42+zczkrCh9SNjww/tx2CC9KnOe3p8s=,tag:0wb+5LM7hhW2+4hbFc7O4A==,type:str]",
+		"ENC[AES256_GCM,data:vbDGHbnnSFocWnEEF7TL+hXK69VkgSksReKOsAoviosCwqnkZbrzax6y5phHXNsgWUZYMwYuWIun2KBJZVZT+vGWkfqUpjmjf6CoU4sag+qq8tx4k4scc6vjS3fW2pAlAhEW3nfv5PGQn1on,iv:XAZmlzZ60WA8l8BND4b1pBv0CzQ6VRFAHvzpgf4pcak=,tag:SWHOlwF56YraJGeQ9odirQ==,type:str]",
+		"ENC[AES256_GCM,data:Uz3ytkA1gLQ9u+mddlPVnJClymnyT9mmhkekmiA4IK3f4ASk2ShYmdokZ2UNhNAKoaTtyZwoqNfDMxAzcRwUFbl8hJF4AFNJcdDhOOZJ6XGY9fhRNbl0/Nqi2sy4g4+0Up9WQ00=,iv:erQI4ZJhJw1AcWPIn3jshtCRP7Uesd8WQg+NiD/fv18=,tag:nLCGsSgftkaj/xrIqrlk/g==,type:str]",
+		"ENC[AES256_GCM,data:PF4N4XcndudfwWd/Db5bAl60loA/ZMQ62NKEXmQu5ElwDjrCJDu4JVRVsgG3sE/Bku0y4GHhofj4YX+758RLcp6egxPiRXsMiZVY1QFbWDB1wd8s+NI7HUnoXBnn5cS1,iv:RXbVUKgD6cL2Hw6o1AaOz17xF2mL1phRsSUiKpzHYFU=,tag:v5gIhBiYaCWv+h/asBtz0w==,type:str]",
+		"ENC[AES256_GCM,data:h9CXhyz5agwMQD2PA1B/duhVlswi/CdhWJeMEBWE2vJy+08+PXXOQexzfn2yPtXoIUddCGVbQ7ohQPYTLaC9MEi03wvvMC57CbAyo5t4GdF1DUHR0cFn/CCCtHzpFg/2DhK2ODIxW8n+mDb0NKVSgBfGtAA=,iv:B3NXYuf0wZs5iVZ1bjNRnoiMedh14htXdxi23f7/Dnw=,tag:0b+WHe0UtnAxeMLoyZxbTQ==,type:str]",
+		"ENC[AES256_GCM,data:thO2CKgBvujFQAvvFvn2MwjqQ3WZa8rkDG8Niq/fjJiI6DVyTIi832lnWD6wvNUR4JRGW9fO/uFXSC1In6d2YID71IKFGklqRaP/jknlKEJEPWi4LBnbMRQtMqbHosM5qUqqeEkQjf6XFX4Jfw==,iv:WyJwqtCNPTwXyc8i7ltPGnCAITzC6GME5nzT05uZckI=,tag:QMyj4iwJV317OMlLzxGRrg==,type:str]",
+		"ENC[AES256_GCM,data:gYLAw5ASedx4pEdTIh3476tNB4sO3qwccfPaWQqZuTt4ZesggV8GMS1OwFPkesDNUZD7Rcui3H2IHvpydXyPfnTczcICGePuC+haGpfCSisBmuJOv0sCkrgAXGcjz1VC3H6KRSLAmf8=,iv:J132GYAFXV2cYcNYZzTP1wPCawe8MoI19VE/jDUiKB4=,tag:oimtnkl64AtVe40xS5d5zg==,type:str]",
+		"ENC[AES256_GCM,data:D696gBvbx1mjRNI0mL1wQXKPUy1rFxmJxH2v1cSbc7e3Bl97l0pBNgU1+cLK9hgXodEreoYaQXBkbXNl318oHccUQyu5Oj/y8JYeeHSW7IxHIN4masJMwFvFjjhFSv4KdyvSniHdSE0=,iv:cbipW3GvLmiGZxERpxSCFi9h2lJTB24oXjskMonjAnI=,tag:OR6KjBlC85m8mDJ7oS6QGw==,type:str]",
+		"ENC[AES256_GCM,data:+EJ2N+FLOovEaTyOdA6hGNgc5KJ8/KPOHO6XJBL3QVKVb3C98xMEK88Ey3DMvW2Z5H2FHOFdKej554JzAwFy4R1VllLxLwIuQjajvm6E//hKqKdp/hQp8HBvxaFSNY4mUmhbwj1SNmIYcSdmM7swa8G81b0K+6cZn9+Aj+8=,iv:EavikaAJGd2FAtf1bH714viGAuMbpVEMwpDoyP87G3c=,tag:DssREY1I9iP2yMBJEt8LdA==,type:str]",
+		"ENC[AES256_GCM,data:7Rifywl3Ar3fNF037vW39VkHOOZA8ItJxZPgdGgZqOFijN3Zzeb9YwBGW1NefeQSTBeu3yMGjw0xc/Ivw1FBLcxRt6+WmmW0mRQT/yHVQcPbBazWLYOJJc6V6F2Usi8O36Tcxt0xCrKa,iv:v3jCRYzW3PcwAfBsWIBG4Dv9uaewJdw86BmBjfhfqQk=,tag:3Ouse/EWPY0AdTTdnPmE5g==,type:str]",
+		"ENC[AES256_GCM,data:Fsnacvzpp06sEVnFoG8UE5cr16KtaT4+EJZaKyqlGYmpkVDG/NfrMfePjfvjvDOvOGp+sEdz81yP6yMWlxHqyYbdO0m6nXyqbrrjUsv7bV/EAS92bg4esd+AQcVEe1wYDA+FgWuPv2MfdT4m2Y0nFbbzpiQz0UY=,iv:FMhCs+ysST6rDWWqFU5UzISq+ub1rg5vNnIq+SDLRAA=,tag:B4FVPrpgzw0bB3PdLcLnBg==,type:str]",
+		"ENC[AES256_GCM,data:n69bCBX/lw0NT1nfPsUpq88IsCjeTAZEac9gfEyMPjl5W1UzHMszsYhSm6D3wnRPnbYBxGX3RIMK5uzlVDn+kcHUjuElhMsliqFvv6AijpIjcSFDe/Othv6A7FqAYNxtsFSQKCdsnI0PKpz9ODzh9OG7SAjNg6w1tTxfbCdjy+/ZhJOE6qZuzugnCb8soeMdqy4c06U0acwIySycTAWT+2QdZSWsIRGfDM5iUPfrAiuZ4cD06jtPm+9wghxucGe2Xx8548BG/ncPUDVEiusMWMUBMPod6nNquRl70fQGbCG4kkmbmehsNSRk2LiH0eNTLNViSLuw2FliwcKO8vvnKb8vu3dYrilR8Z8dEFqkGQ6LBuLXEPsyrv3/fkuV8axY4EDIAdrBbXxQZB5HsBHM3nudgiDQdLXjV6bzHQfvvPq9k8wBN5Q32hXC0Rp2bNWLONne+dsat64LY0oUWSzkIPptV11OitE+wbei/2stfhaGPZsXV57tG9GRQDlNs2vNBpkqf5F9Fm6hOsxHMONozi8xrxlDXF7zTBFWS2+RpVb98eByPPryHqUH9+RbkFYkJJmWXUI13v05LvF9sCJtDtrm7jDZatYMve/r5bXUw/huOn0i44jn8TJQEwBGi7OxPicV2xMPgRq89NEyy3Rw4OS1KCmeTg+SFVJhjLiPzcabYYVLNVF40t0pSwZIEEyFSovzoHTuO8B74yF5BJVd8rK2YBJFdsE4Q9vNz34KJFjl8B+bxpORBVza+YVTV++Fgo6+a8FcUGKpSTfDvP5Br+f+aZ8QANnzbbxd15U1NWiRWy4immAxv7FG0JpCH9dgtMOjv4ulBDCDzI3SxMYul35VxTnZIJuqJfFJees2W6gZr2ZhpT+byVn/NW+7B7SHEUppeJQe2+ZziN2oq+ThRkE9kn+50N5cIEgWyYRxBaOtsPoRKu6wmWs7l72O43T3loSGlDh30oNTNHQ0qbNalVmIl1VmCZihwnQqoyXU05E=,iv:FPtUfbRhVHiW/u10lJC/33dJblp55KXQ+K3RBhgLDvU=,tag:vvQgO5aNueQVVhV86tFZag==,type:str]"
 	],
 	"sops": {
 		"kms": [
 			{
 				"arn": "arn:aws:kms:eu-central-1:631260641272:alias/Hame-ryhti",
-				"created_at": "2024-06-18T11:14:31Z",
-				"enc": "AQICAHiE41A2/p59xbFWiUt+oC17wSyQhQ4tvk+1zIy71M/m3QHIFe0iJDGkKZzVMwb+z+sUAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMB9CgQQxK6FWVXIFhAgEQgDurgPZHfe7BDymhK43pAOgJsw2B+KrjqpBGVKh/eSBwmh2Vb8NasF3d74x1UEhfyH0hUCBlwugF3QHjRg==",
+				"created_at": "2024-09-04T14:13:38Z",
+				"enc": "AQICAHiE41A2/p59xbFWiUt+oC17wSyQhQ4tvk+1zIy71M/m3QH420VPgoYWhzjs1gC7pnlKAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM2VKfz6fy9OUnPE5uAgEQgDv85IfN2HcuEvqwbKlpwiuPtOT3WunrgS5LNSyRp9NjQw4nznTs+LlcmT+zdUalwHfh7yaXLs2x8xlCRQ==",
 				"aws_profile": ""
 			}
 		],
@@ -69,8 +70,8 @@
 		"azure_kv": null,
 		"hc_vault": null,
 		"age": null,
-		"lastmodified": "2024-06-18T11:14:33Z",
-		"mac": "ENC[AES256_GCM,data:c2WY6F3z+4d41PDZ1ZmrkMuDsyGd51bBSF5kL0vud/K3ec94VSiyTIZgG62Owz41m3TffSTL6bErYUBWW7UqXbaZCqNK7y9Y86VUXsYrXbEG9Gw+gia9vxE2sfcv7sATBojwJXYkb26809ids0kdJHlN82hgfrlBL7cCF0umq4U=,iv:idNhP2ENp30p7AfN2g9DSj7oeRwUjc+zM1tlQruJGRQ=,tag:KppKhIuZMKrrwd3mKnWiTQ==,type:str]",
+		"lastmodified": "2024-09-04T14:13:39Z",
+		"mac": "ENC[AES256_GCM,data:5dfdwMvxN2huG0ZR4umJYYNaRsoej/7DXyWNJPYG0UwDYI7vjS5lT7hGK98yBWTz9ktwI5GMAqs8g0MtXepAF4C+yEYeyvmgKt7WTghbGRCz0NRBC5VhBrQWPj51LKqhhJmC/w49y6ooDymGFDl0s0p2eEnrfTTReTpuCGqg5Ow=,iv:H0hJMqczqecYnFWWYULWgXQdrYkcWHfbyBXwjIKUHA8=,tag:Ku2sYlYc7BvVt+ZwKvyQJQ==,type:str]",
 		"pgp": null,
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.8.1"

--- a/infra/iam.tf
+++ b/infra/iam.tf
@@ -78,15 +78,23 @@ resource "aws_iam_policy" "lambda_update_policy" {
       {
         "Effect" : "Allow",
         "Action" : [
-          "lambda:CreateFunction",
-          "lambda:UpdateFunctionCode",
-          "lambda:InvokeFunction",
-          "lambda:UpdateFunctionConfiguration"
+          # Necessary IAM permission to publish an image in ECR
+          "ecr:DescribeImages",
+          "ecr:DescribeRepositories",
+          "ecr:GetAuthorizationToken",
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchGetImage",
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:InitiateLayerUpload",
+          "ecr:UploadLayerPart",
+          "ecr:CompleteLayerUpload",
+          "ecr:PutImage"
         ],
         "Resource" : [
-          aws_lambda_function.db_manager.arn,
-          aws_lambda_function.koodistot_loader.arn,
-          aws_lambda_function.ryhti_client.arn
+          aws_ecr_repository.db_manager.arn,
+          aws_ecr_repository.koodistot_loader.arn,
+          aws_ecr_repository.ryhti_client.arn,
+          aws_ecr_repository.mml_loader.arn
           ]
       }
     ]

--- a/infra/lambda.tf
+++ b/infra/lambda.tf
@@ -1,9 +1,7 @@
 resource "aws_lambda_function" "db_manager" {
   function_name = "${var.prefix}-db_manager"
-  filename      = "../database/db_manager.zip"
-  runtime       = "python3.12"
-  handler       = "db_manager.handler"
-  memory_size   = 128
+  image_uri     = "${aws_ecr_repository.db_manager.repository_url}:latest"
+  package_type  = "Image"
   timeout       = 120
 
   role = aws_iam_role.lambda_exec.arn
@@ -28,12 +26,21 @@ resource "aws_lambda_function" "db_manager" {
   tags = merge(local.default_tags, { Name = "${var.prefix}-db_manager" })
 }
 
+resource "aws_ecr_repository" "db_manager" {
+  name                 = "${var.prefix}-db_manager"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = merge(local.default_tags, { Name = "${var.prefix}-db_manager" })
+}
+
 resource "aws_lambda_function" "koodistot_loader" {
   function_name = "${var.prefix}-koodistot_loader"
-  filename      = "../database/koodistot_loader.zip"
-  runtime       = "python3.12"
-  handler       = "koodistot_loader.handler"
-  memory_size   = 128
+  image_uri     = "${aws_ecr_repository.koodistot_loader.repository_url}:latest"
+  package_type  = "Image"
   timeout       = 120
 
   role = aws_iam_role.lambda_exec.arn
@@ -55,6 +62,16 @@ resource "aws_lambda_function" "koodistot_loader" {
   tags = merge(local.default_tags, { Name = "${var.prefix}-koodistot_loader" })
 }
 
+resource "aws_ecr_repository" "koodistot_loader" {
+  name                 = "${var.prefix}-koodistot_loader"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = merge(local.default_tags, { Name = "${var.prefix}-koodistot_loader" })
+}
 
 resource "aws_lambda_permission" "cloudwatch_call_koodistot_loader" {
     action = "lambda:InvokeFunction"
@@ -66,10 +83,8 @@ resource "aws_lambda_permission" "cloudwatch_call_koodistot_loader" {
 
 resource "aws_lambda_function" "ryhti_client" {
   function_name = "${var.prefix}-ryhti_client"
-  filename      = "../database/ryhti_client.zip"
-  runtime       = "python3.12"
-  handler       = "ryhti_client.handler"
-  memory_size   = 128
+  image_uri     = "${aws_ecr_repository.ryhti_client.repository_url}:latest"
+  package_type  = "Image"
   timeout       = 120
 
   role = aws_iam_role.lambda_exec.arn
@@ -94,10 +109,59 @@ resource "aws_lambda_function" "ryhti_client" {
   tags = merge(local.default_tags, { Name = "${var.prefix}-ryhti_client" })
 }
 
+resource "aws_ecr_repository" "ryhti_client" {
+  name                 = "${var.prefix}-ryhti_client"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = merge(local.default_tags, { Name = "${var.prefix}-ryhti_client" })
+}
 
 resource "aws_lambda_permission" "cloudwatch_call_ryhti_client" {
     action = "lambda:InvokeFunction"
     function_name = aws_lambda_function.ryhti_client.function_name
     principal = "events.amazonaws.com"
     source_arn = aws_cloudwatch_event_rule.lambda_ryhti_client.arn
+}
+
+resource "aws_lambda_function" "mml_loader" {
+  function_name = "${var.prefix}-mml_loader"
+  image_uri     = "${aws_ecr_repository.mml_loader.repository_url}:latest"
+  package_type  = "Image"
+  timeout       = 120
+
+  role = aws_iam_role.lambda_exec.arn
+  vpc_config {
+    subnet_ids         = data.aws_subnets.private.ids
+    security_group_ids = [aws_security_group.lambda.id]
+  }
+
+  environment {
+    variables = {
+      AWS_REGION_NAME     = var.AWS_REGION_NAME
+      DB_INSTANCE_ADDRESS = aws_db_instance.main_db.address
+      DB_MAIN_NAME        = var.hame_db_name
+      DB_MAINTENANCE_NAME = "postgres"
+      READ_FROM_AWS       = 1
+      DB_SECRET_RW_ARN    = aws_secretsmanager_secret.hame-db-rw.arn
+      SYKE_APIKEY         = var.syke_apikey
+      XROAD_SERVER_ADDRESS = data.aws_network_interface.interface_tags.private_ip
+      XROAD_MEMBER_CODE   = var.x-road_member_code
+    }
+  }
+  tags = merge(local.default_tags, { Name = "${var.prefix}-mml_loader" })
+}
+
+resource "aws_ecr_repository" "mml_loader" {
+  name                 = "${var.prefix}-mml_loader"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = merge(local.default_tags, { Name = "${var.prefix}-mml_loader" })
 }

--- a/infra/lambda.tf
+++ b/infra/lambda.tf
@@ -147,9 +147,7 @@ resource "aws_lambda_function" "mml_loader" {
       DB_MAINTENANCE_NAME = "postgres"
       READ_FROM_AWS       = 1
       DB_SECRET_RW_ARN    = aws_secretsmanager_secret.hame-db-rw.arn
-      SYKE_APIKEY         = var.syke_apikey
-      XROAD_SERVER_ADDRESS = data.aws_network_interface.interface_tags.private_ip
-      XROAD_MEMBER_CODE   = var.x-road_member_code
+      MML_APIKEY          = var.mml_apikey
     }
   }
   tags = merge(local.default_tags, { Name = "${var.prefix}-mml_loader" })

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -103,6 +103,11 @@ variable "syke_apikey" {
   type        = string
 }
 
+variable "mml_apikey" {
+  description = "MML API key for MML Loader"
+  type        = string
+}
+
 variable "public-subnet-count" {
   description = "TODO"
   type        = number


### PR DESCRIPTION
Store lambda functions as docker images in AWS ECR. That way, they start fast.

Also, added missing mml_loader definition.

Fix #320 