### PR TITLE
Fix Dockerfile layer order

### DIFF
--- a/database/db_manager.Dockerfile
+++ b/database/db_manager.Dockerfile
@@ -1,5 +1,9 @@
 FROM public.ecr.aws/lambda/python:3.12
 
+# Install Python dependencies
+COPY requirements.txt ${LAMBDA_TASK_ROOT}/requirements.txt
+RUN pip3 install -r requirements.txt --target "${LAMBDA_TASK_ROOT}"
+
 # Copy function code
 COPY database/db_manager/db_manager.py ${LAMBDA_TASK_ROOT}/db_manager.py
 COPY database/migrations ${LAMBDA_TASK_ROOT}/migrations
@@ -9,8 +13,5 @@ COPY database/base.py ${LAMBDA_TASK_ROOT}/base.py
 COPY database/codes.py ${LAMBDA_TASK_ROOT}/codes.py
 COPY database/models.py ${LAMBDA_TASK_ROOT}/models.py
 COPY database/triggers.py ${LAMBDA_TASK_ROOT}/triggers.py
-COPY requirements.txt ${LAMBDA_TASK_ROOT}/requirements.txt
-
-RUN pip3 install -r requirements.txt --target "${LAMBDA_TASK_ROOT}"
 
 CMD [ "db_manager.handler" ]

--- a/database/koodistot_loader.Dockerfile
+++ b/database/koodistot_loader.Dockerfile
@@ -1,13 +1,14 @@
 FROM public.ecr.aws/lambda/python:3.12
 
+# Install Python dependencies
+COPY requirements.txt ${LAMBDA_TASK_ROOT}/requirements.txt
+RUN pip3 install -r requirements.txt --target "${LAMBDA_TASK_ROOT}"
+
 # Copy function code
 COPY database/koodistot_loader/koodistot_loader.py ${LAMBDA_TASK_ROOT}/koodistot_loader.py
 COPY database/db_helper.py  ${LAMBDA_TASK_ROOT}/db_helper.py
 COPY database/base.py ${LAMBDA_TASK_ROOT}/base.py
 COPY database/codes.py ${LAMBDA_TASK_ROOT}/codes.py
 COPY database/models.py ${LAMBDA_TASK_ROOT}/models.py
-COPY requirements.txt ${LAMBDA_TASK_ROOT}/requirements.txt
-
-RUN pip3 install -r requirements.txt --target "${LAMBDA_TASK_ROOT}"
 
 CMD [ "koodistot_loader.handler" ]

--- a/database/mml_loader.Dockerfile
+++ b/database/mml_loader.Dockerfile
@@ -1,13 +1,15 @@
 FROM public.ecr.aws/lambda/python:3.12
 
+# Install Python dependencies
+COPY requirements.txt ${LAMBDA_TASK_ROOT}/requirements.txt
+RUN pip3 install -r requirements.txt --target "${LAMBDA_TASK_ROOT}"
+
 # Copy function code
 COPY database/mml_loader/mml_loader.py ${LAMBDA_TASK_ROOT}/mml_loader.py
 COPY database/db_helper.py  ${LAMBDA_TASK_ROOT}/db_helper.py
 COPY database/base.py ${LAMBDA_TASK_ROOT}/base.py
 COPY database/codes.py ${LAMBDA_TASK_ROOT}/codes.py
 COPY database/models.py ${LAMBDA_TASK_ROOT}/models.py
-COPY requirements.txt ${LAMBDA_TASK_ROOT}/requirements.txt
 
-RUN pip3 install -r requirements.txt --target "${LAMBDA_TASK_ROOT}"
 
 CMD [ "mml_loader.handler" ]

--- a/database/ryhti_client.Dockerfile
+++ b/database/ryhti_client.Dockerfile
@@ -1,13 +1,14 @@
 FROM public.ecr.aws/lambda/python:3.12
 
+# Install Python dependencies
+COPY requirements.txt ${LAMBDA_TASK_ROOT}/requirements.txt
+RUN pip3 install -r requirements.txt --target "${LAMBDA_TASK_ROOT}"
+
 # Copy function code
 COPY database/ryhti_client/ryhti_client.py ${LAMBDA_TASK_ROOT}/ryhti_client.py
 COPY database/db_helper.py  ${LAMBDA_TASK_ROOT}/db_helper.py
 COPY database/base.py ${LAMBDA_TASK_ROOT}/base.py
 COPY database/codes.py ${LAMBDA_TASK_ROOT}/codes.py
 COPY database/models.py ${LAMBDA_TASK_ROOT}/models.py
-COPY requirements.txt ${LAMBDA_TASK_ROOT}/requirements.txt
-
-RUN pip3 install -r requirements.txt --target "${LAMBDA_TASK_ROOT}"
 
 CMD [ "ryhti_client.handler" ]


### PR DESCRIPTION
Previously python dependency install layer was run always when any of the files were modified. Change that step before copying files that are likely to be changed.