### PR TITLE
Change backport action

### DIFF
--- a/.github/workflows/vsl-backport.yml
+++ b/.github/workflows/vsl-backport.yml
@@ -5,22 +5,33 @@ on:
       - closed
       - labeled
 
+permissions:
+  contents: read
+
 jobs:
   backport:
     name: Backport
     runs-on: ubuntu-latest
-    # Only react to merged PRs for security reasons.
-    # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
+
+    permissions:
+      pull-requests: write
+
     if: >
       github.event.pull_request.merged
       && (
-        github.event.action == 'closed'
+        (
+          github.event.action == 'closed'
+          && contains(join(github.event.pull_request.labels.*.name), 'backport')
+        )
         || (
           github.event.action == 'labeled'
           && contains(github.event.label.name, 'backport')
         )
       )
     steps:
-      - uses: tibdex/backport@v2
+      - name: Backport Bot
+        id: backport
+
+        uses: m-kuhn/backport@v1.2.7
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Change to M-kuhn's fork because it adds support for backporting rebase merges and merge commits, squash commits are also supported.

Inspired by the QGIS backport action